### PR TITLE
🔒 Security: S3パブリックアクセスブロック・CloudFront OAC限定アクセス

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -20,32 +20,35 @@ Resources:
     Properties:
       BucketName: !Sub '${BucketName}-${Environment}-${AWS::AccountId}'
       PublicAccessBlockConfiguration:
-        BlockPublicAcls: false
-        BlockPublicPolicy: false
-        IgnorePublicAcls: false
-        RestrictPublicBuckets: false
-      WebsiteConfiguration:
-        IndexDocument: index.html
-        ErrorDocument: index.html
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       CorsConfiguration:
         CorsRules:
-          - AllowedHeaders: ['*']
+          - AllowedHeaders:
+              - Content-Type
             AllowedMethods: [GET, HEAD]
-            AllowedOrigins: ['*']
+            AllowedOrigins:
+              - !Sub 'https://${GameDistribution.DomainName}'
             MaxAge: 3600
 
-  # S3 Bucket Policy for public read access
+  # S3 Bucket Policy for CloudFront OAC access only
   GameBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
       Bucket: !Ref GameBucket
       PolicyDocument:
         Statement:
-          - Sid: PublicReadGetObject
+          - Sid: AllowCloudFrontServicePrincipal
             Effect: Allow
-            Principal: '*'
+            Principal:
+              Service: cloudfront.amazonaws.com
             Action: s3:GetObject
             Resource: !Sub 'arn:aws:s3:::${GameBucket}/*'
+            Condition:
+              StringEquals:
+                AWS:SourceArn: !Sub 'arn:aws:cloudfront::${AWS::AccountId}:distribution/${GameDistribution}'
 
   # CloudFront Origin Access Control
   OriginAccessControl:


### PR DESCRIPTION
## 概要
セキュリティ静的解析により検出されたCloudFormation設定の脆弱性を修正します。

## 修正内容
### 🔴 Critical: S3バケットのパブリックアクセス全開放 (OWASP A01:2021)
- `PublicAccessBlockConfiguration`を全て`true`に変更
- S3 BucketPolicyを`Principal: '*'`からCloudFront OACの`ServicePrincipal`のみに制限
- `WebsiteConfiguration`を削除（CloudFront OAC経由のため不要）

### 🟡 Medium: CORSの過剰許可 (OWASP A05:2021)
- `AllowedOrigins: ['*']`をCloudFrontドメインに限定
- `AllowedHeaders: ['*']`を`Content-Type`に限定

## デプロイ時の注意
- 既存のS3 Website URLでの直接アクセスは不可になります
- CloudFront経由(`https://`ドメイン)でのアクセスに統一されます

## セキュリティ基準
- OWASP Top 10 2021準拠
- AWS Well-Architected Framework セキュリティの柱